### PR TITLE
Add "--std=c++11" in makefile and fix a bug when judge if users win

### DIFF
--- a/game.cpp
+++ b/game.cpp
@@ -492,7 +492,7 @@ Status Game::judge() {
 	// win 
 	for (int i = 0; i < 4; ++i) {
 		for (int j = 0; j < 4; ++j) {
-			if (map[i][i] == 2048) {
+			if (map[i][j] == 2048) {
 				return SWin;
 			}
 		}

--- a/makefile
+++ b/makefile
@@ -1,5 +1,5 @@
 out: game.o main.cpp
-	g++ -o out game.o main.cpp -lncurses
+	g++ -o out game.o main.cpp -lncurses --std=c++11
 
 game.o: game.cpp
-	g++ -c game.cpp -o game.o
+	g++ -c game.cpp -o game.o --std=c++11


### PR DESCRIPTION
1. add "--std=c++" in makefile
    because this project use c11 standard grammer,so add --std=c++ to make
complier complie the project using c11 standard
2. fix a bug when judge if users win
    change "map[i][i] == 2048" into "map[i][j] == 2048" in judge function
in game.cpp